### PR TITLE
Stabilize UI lifecycle and data bridge: fix setData freeze/crash, harden ESC dismissal, enforce full close-before-open

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
 hytale {
     allowOp.set(true)
     patchline.set("release")
+    version.set("0.5.0")
     includeLocalMods.set(false)
     manifest {
         version.set(project.version.toString())

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "li.kelp"
-version = "1.0.28"
+version = "1.0.29"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/li/kelp/vuetale/app/App.kt
+++ b/src/main/kotlin/li/kelp/vuetale/app/App.kt
@@ -1,4 +1,5 @@
-﻿package li.kelp.vuetale.app
+﻿
+package li.kelp.vuetale.app
 
 import com.caoccao.javet.values.V8Value
 import com.caoccao.javet.values.reference.V8ValueObject
@@ -6,11 +7,19 @@ import li.kelp.vuetale.events.EventRegistry
 import li.kelp.vuetale.javascript.JSEngine
 import li.kelp.vuetale.tree.Element
 import li.kelp.vuetale.tree.RootElement
+import java.lang.reflect.Array as JArray
+import java.lang.reflect.Modifier
+import java.util.IdentityHashMap
 import java.util.logging.Logger
 
 data class Dependency(var origin: String, var name: String, var dependents: Int)
 
 class App(val owner: String, val type: AppType, var componentPath: String? = null) {
+
+    companion object {
+        private const val MAX_SETDATA_NORMALIZE_DEPTH = 8
+    }
+
     private val logger: Logger = Logger.getLogger("App $owner-$type")
     private fun getEngine() = JSEngine.instance
 
@@ -163,8 +172,9 @@ class App(val owner: String, val type: AppType, var componentPath: String? = nul
                                 .close()
                         }
                     } else {
+                        val normalized = normalizeForJs(value)
                         engine.runOnV8Thread {
-                            engine.loaderCtx.invoke<V8Value>("setAppData", getId(), key, value).close()
+                            engine.loaderCtx.invoke<V8Value>("setAppData", getId(), key, normalized).close()
                         }
                     }
                 } catch (e: Exception) {
@@ -211,27 +221,24 @@ class App(val owner: String, val type: AppType, var componentPath: String? = nul
         dataCache[key] = value
         val engine = getEngine()
         if (!engine.isAlive) {
-            // Engine is shutting down; skip sending to V8. Data is still cached and
-            // will be re-pushed when the engine restarts.
             logger.fine("Skipping setData('$key') because JSEngine is not alive")
             return
         }
-        try {
-            // If value looks like a JVM function/functional object, register it and
-            // send a hostFn marker to JS instead of the raw object.
-            if (value != null && isJvmFunction(value)) {
-                val hostId = JSEngine.instance.bridge.registerHostCallback(getId(), value)
-                engine.runOnV8Thread {
+        val normalized = normalizeForJs(value)
+        // Fire-and-forget: setData is often called from latency-sensitive game threads.
+        // Waiting on V8 here causes visible freezes when payloads are large (e.g. non-empty arrays)
+        // or when teardown/render work is in progress.
+        engine.submitToV8Thread {
+            try {
+                if (value != null && isJvmFunction(value)) {
+                    val hostId = JSEngine.instance.bridge.registerHostCallback(getId(), value)
                     engine.loaderCtx.invoke<V8Value>("setAppData", getId(), key, mapOf("_vtHostFnId" to hostId)).close()
+                } else {
+                    engine.loaderCtx.invoke<V8Value>("setAppData", getId(), key, normalized).close()
                 }
-            } else {
-                engine.runOnV8Thread {
-                    engine.loaderCtx.invoke<V8Value>("setAppData", getId(), key, value).close()
-                }
+            } catch (e: Exception) {
+                logger.warning("setData failed for app '${getId()}' key='$key' (queued to V8): ${e.message}")
             }
-        } catch (e: Exception) {
-            // Swallow exceptions caused by engine shutdown; data remains in cache.
-            logger.warning("setData failed for app '${getId()}' key='$key': ${e.message}")
         }
     }
 
@@ -260,6 +267,78 @@ class App(val owner: String, val type: AppType, var componentPath: String? = nul
         // crude: check for any 'invoke' method or 'apply' etc.
         if (cls.methods.any { it.name == "invoke" || it.name == "apply" || it.name == "accept" || it.name == "call" }) return true
         return false
+    }
+
+    private fun normalizeForJs(value: Any?): Any? {
+        return normalizeForJsInternal(value, 0, IdentityHashMap())
+    }
+
+    private fun normalizeForJsInternal(value: Any?, depth: Int, seen: IdentityHashMap<Any, Boolean>): Any? {
+        if (value == null) return null
+        if (depth > MAX_SETDATA_NORMALIZE_DEPTH) {
+            return value.toString()
+        }
+        if (isJvmFunction(value)) return value
+
+        return when (value) {
+            is String, is Number, is Boolean -> value
+            is Char -> value.toString()
+            is Enum<*> -> value.name
+            is Map<*, *> -> {
+                val out = LinkedHashMap<String, Any?>()
+                value.forEach { (k, v) ->
+                    out[k?.toString() ?: "null"] = normalizeForJsInternal(v, depth + 1, seen)
+                }
+                out
+            }
+
+            is Iterable<*> -> value.map { normalizeForJsInternal(it, depth + 1, seen) }
+            else -> {
+                val cls = value.javaClass
+                if (cls.isArray) {
+                    val len = JArray.getLength(value)
+                    val out = ArrayList<Any?>(len)
+                    for (i in 0 until len) {
+                        out.add(normalizeForJsInternal(JArray.get(value, i), depth + 1, seen))
+                    }
+                    return out
+                }
+
+                if (isSimpleJdkType(cls)) {
+                    return value.toString()
+                }
+
+                if (seen.put(value, true) != null) {
+                    return null
+                }
+                try {
+                    val out = LinkedHashMap<String, Any?>()
+                    var c: Class<*>? = cls
+                    while (c != null && c != Any::class.java) {
+                        c.declaredFields.forEach { f ->
+                            if (Modifier.isStatic(f.modifiers)) return@forEach
+                            if (f.isSynthetic) return@forEach
+                            if (f.name.startsWith("$")) return@forEach
+                            runCatching {
+                                f.isAccessible = true
+                                out[f.name] = normalizeForJsInternal(f.get(value), depth + 1, seen)
+                            }
+                        }
+                        c = c.superclass
+                    }
+                    out
+                } finally {
+                    seen.remove(value)
+                }
+            }
+        }
+    }
+
+    private fun isSimpleJdkType(cls: Class<*>): Boolean {
+        val name = cls.name
+        return name.startsWith("java.time.") ||
+            name == "java.util.UUID" ||
+            name.startsWith("java.math.")
     }
 
     fun mount() {

--- a/src/main/kotlin/li/kelp/vuetale/app/App.kt
+++ b/src/main/kotlin/li/kelp/vuetale/app/App.kt
@@ -94,7 +94,7 @@ class App(val owner: String, val type: AppType, var componentPath: String? = nul
         val resolvedPath = componentPath?.removePrefix("vt:")
         if (resolvedPath != null) {
             componentPath = resolvedPath
-            logger.info("Creating app '${getId()}' with component: $resolvedPath")
+            logger.fine("Creating app '${getId()}' with component: $resolvedPath")
             try {
                 getEngine().preloadComponent(resolvedPath)
             } catch (e: Exception) {
@@ -354,7 +354,7 @@ class App(val owner: String, val type: AppType, var componentPath: String? = nul
             _vt.getUserApp('${getId()}').mount(_vt.getUserAppRef('${getId()}'));
             globalThis.__vt_currentAppId = null;
         """.trimIndent())
-        logger.info("Mounted App '${getId()}'")
+        logger.fine("Mounted App '${getId()}'")
         isMounted = true
     }
 
@@ -402,6 +402,38 @@ class App(val owner: String, val type: AppType, var componentPath: String? = nul
             } catch (e: Exception) {
                 logger.fine("Failed to unregister host callbacks for ${getId()} during unmount: ${e.message}")
             }
+        }
+    }
+
+    /**
+     * Fully tear down this app before replacing it with another page.
+     *
+     * Unlike [unmount], this blocks until `_vt.removeUserApp(id)` has run on the V8 thread,
+     * guaranteeing the old JS app and data maps are gone before a new app is created
+     * under the same owner/type id.
+     */
+    fun unmountFullyBlocking() {
+        val appId = getId()
+        val engine = getEngine()
+
+        if (engine.isAlive) {
+            runCatching {
+                engine.runOnV8Thread {
+                    engine.loaderCtx.invoke<V8Value>("removeUserApp", appId).close()
+                }
+            }.onFailure {
+                logger.warning("Full unmount failed for app '$appId': ${it.message}")
+            }
+        }
+
+        isMounted = false
+        isDirty = false
+        onDirty = null
+        eventRegistry.closeAll()
+        runCatching {
+            JSEngine.instance.bridge.unregisterHostCallbacksForApp(appId)
+        }.onFailure {
+            logger.fine("Failed to unregister host callbacks for $appId during full unmount: ${it.message}")
         }
     }
 

--- a/src/main/kotlin/li/kelp/vuetale/app/AppManager.kt
+++ b/src/main/kotlin/li/kelp/vuetale/app/AppManager.kt
@@ -39,18 +39,18 @@ object AppManager {
         apps[app.getId()] = app
     }
 
-    fun removeApp(id: String) {
+    fun removeApp(id: String, unmount: Boolean = true) {
         getApp(id)?.let {
-            if (it.isMounted) {
+            if (unmount && it.isMounted) {
                 it.unmount()
             }
         }
         apps.remove(id)
     }
 
-    fun removeApp(owner: String, type: AppType) {
+    fun removeApp(owner: String, type: AppType, unmount: Boolean = true) {
         val id = getAppId(owner, type)
-        removeApp(id)
+        removeApp(id, unmount)
     }
 
     fun removeOwnerApps(owner: String) {

--- a/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
+++ b/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
@@ -89,9 +89,11 @@ class PlayerUi internal constructor(
             val oldPage = page
             if (oldPage != null) {
                 oldPage.prepareForDismissal()
-                // Also unmounts the old app (async JS teardown sent to the V8 thread)
-                // and removes it from the registry so the new page gets a fresh App.
-                AppManager.removeApp(oldPage.app.owner, oldPage.app.type)
+                // Fully tear down the old app before creating the new one.
+                // This blocks until JS-side USER_APPS/USER_APPS_DATA are cleaned,
+                // preventing overlap when replacing a page quickly.
+                oldPage.app.unmountFullyBlocking()
+                AppManager.removeApp(oldPage.app.owner, oldPage.app.type, unmount = false)
             }
             val newPage = VuetaleUIPage(pRef, ownerId, AppType.Page, lifetime, componentPath)
             page = newPage

--- a/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
+++ b/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
@@ -153,11 +153,11 @@ class PlayerUi internal constructor(
      * @param componentPath  Module path of the Vue component, e.g. `"vt:@core/huds/ActionBar"`.
      */
     fun openHud(componentPath: String): PlayerUi {
-        val (ref, store, player) = requirePlayerContext()
+        val (_, _, player) = requirePlayerContext()
         CompletableFuture.runAsync {
             val newHud = VuetaleUIHud(requirePlayerRef(), ownerId, componentPath)
             hud = newHud
-            player.hudManager.setCustomHud(requirePlayerRef(), newHud)
+            player.hudManager.addCustomHud(requirePlayerRef(), newHud)
         }
         return this
     }
@@ -171,7 +171,7 @@ class PlayerUi internal constructor(
     /** Hide the current HUD, if any. */
     fun closeHud() {
         val h = hud ?: return
-        val (ref, store, player) = requirePlayerContext()
+        val (_, _, player) = requirePlayerContext()
         CompletableFuture.runAsync {
             h.hide()
             player.hudManager.resetHud(requirePlayerRef())

--- a/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
+++ b/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
@@ -107,8 +107,15 @@ class PlayerUi internal constructor(
      * whatever server-side mechanism you use to navigate the player away from the page.
      */
     fun closePage() {
-        page?.app?.let { app ->
-            if (app.isMounted) app.unmount()
+        val p = page
+        if (p != null) {
+            // Deactivate BEFORE unmounting so that Vue's async teardown (which runs on the
+            // V8 thread and calls markDirty()) cannot trigger onDirty → sendUpdate() while
+            // Hytale is simultaneously dismissing the page.  Without this, the ForkJoin
+            // sendUpdate call races with super.onDismiss() holding the page lock, causing
+            // a thread-blocking timeout.
+            p.prepareForDismissal()
+            if (p.app.isMounted) p.app.unmount()
         }
 
         playerRef?.let { ref ->

--- a/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
+++ b/src/main/kotlin/li/kelp/vuetale/app/PlayerUi.kt
@@ -81,6 +81,18 @@ class PlayerUi internal constructor(
         val pRef = requirePlayerRef()
         val (ref, store, player) = requirePlayerContext()
         CompletableFuture.runAsync {
+            // If a page is already open, deactivate and evict its app from AppManager
+            // BEFORE constructing the new VuetaleUIPage.  The VuetaleUIPage constructor
+            // reuses any existing App under the same owner+type key; if the old app is
+            // still registered both pages share the same App object, and the delayed
+            // onDismiss of the old page would then remove the *new* app from AppManager.
+            val oldPage = page
+            if (oldPage != null) {
+                oldPage.prepareForDismissal()
+                // Also unmounts the old app (async JS teardown sent to the V8 thread)
+                // and removes it from the registry so the new page gets a fresh App.
+                AppManager.removeApp(oldPage.app.owner, oldPage.app.type)
+            }
             val newPage = VuetaleUIPage(pRef, ownerId, AppType.Page, lifetime, componentPath)
             page = newPage
             player.pageManager.openCustomPage(ref, store, newPage)

--- a/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIHud.kt
+++ b/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIHud.kt
@@ -37,7 +37,7 @@ class VuetaleUIHud(
     appOwner: String,
     /** Initial component to render, e.g. `"vt:@core/huds/MyHud"`. */
     componentPath: String? = null,
-) : CustomUIHud(playerRef) {
+) : CustomUIHud(playerRef, appOwner) {
 
     private val logger = Logger.getLogger("VuetaleUIHud[$appOwner]")
 

--- a/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIPage.kt
+++ b/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIPage.kt
@@ -205,7 +205,6 @@ class VuetaleUIPage(
      * forever.  Dispatching here keeps the V8 tick non-blocking.
      */
     private fun sendUpdateAsync(cmdBuilder: UICommandBuilder, evtBuilder: UIEventBuilder, lockInterface: Boolean) {
-        logger.info("[VuetaleUIPage] sendUpdateAsync(evtBuilder): called for page ${app.getId()}")
         if (DebugConfig.enabled) logger.info ("[vuetaledebug] Update render:\n${app.root.render(0)}")
 
         CompletableFuture.runAsync {
@@ -214,7 +213,6 @@ class VuetaleUIPage(
     }
 
     private fun sendUpdateAsync(cmdBuilder: UICommandBuilder) {
-        logger.info("[VuetaleUIPage] sendUpdateAsync: called for page ${app.getId()}")
         if (DebugConfig.enabled) logger.info ("[vuetaledebug] Update render:\n${app.root.render(0)}")
 
         CompletableFuture.runAsync {
@@ -322,9 +320,7 @@ class VuetaleUIPage(
         // sent by the client after pressing ESC). Without this guard, runOnV8Thread's
         // Future.get() can throw InterruptedException if the thread is interrupted
         // during page teardown.
-            logger.info("[VuetaleUIPage] handleDataEvent: entry isActive=$isActive, routingKey='${data.routingKey}'")
             if (!isActive) {
-                logger.info("[VuetaleUIPage] handleDataEvent: isActive=false, dropping event for routingKey='${data.routingKey}'")
                 return
             }
 
@@ -335,7 +331,6 @@ class VuetaleUIPage(
         val value = data.value
 
         try {
-                logger.info("[VuetaleUIPage] handleDataEvent: dispatching to V8 thread for routingKey='$routingKey'")
                 JSEngine.instance.runOnV8Thread {
                     // Re-fetch the binding *inside* the V8 task so we always use the live reference.
                     // If a hot-reload fired in the meantime, forceReset() will have cleared the
@@ -345,7 +340,6 @@ class VuetaleUIPage(
                         logger.warning("No binding found for routingKey='$routingKey' (may be stale after hot-reload)")
                         return@runOnV8Thread
                     }
-                    logger.info("[VuetaleUIPage] handleDataEvent: invoking callback for routingKey='$routingKey'")
                     runCatching {
                         liveBinding.callback.callVoid(null, value)
                     }.onFailure {
@@ -367,10 +361,8 @@ class VuetaleUIPage(
         // If dismissal started while the callback was running, skip the ack to avoid
         // racing sendUpdate() against Hytale's page teardown lock path.
         if (!isActive) {
-            logger.info("[VuetaleUIPage] handleDataEvent: isActive=false after callback, skipping sendUpdate ack for routingKey='$routingKey'")
             return
         }
-        logger.info("[VuetaleUIPage] handleDataEvent: calling sendUpdate for routingKey='$routingKey'")
         runCatching { sendUpdate() }
     }
 
@@ -388,7 +380,6 @@ class VuetaleUIPage(
      * blocking timeout.
      */
     internal fun prepareForDismissal() {
-        logger.info("[VuetaleUIPage] prepareForDismissal: called for page ${app.getId()}")
         isActive = false
         app.onDirty = null
         app.isDirty = false
@@ -399,7 +390,6 @@ class VuetaleUIPage(
     // ── onDismiss ──────────────────────────────────────────────────────────
 
     override fun onDismiss(ref: Ref<EntityStore>, store: Store<EntityStore>) {
-        logger.info("[VuetaleUIPage] onDismiss: called for page ${app.getId()}")
         // Prevent any in-flight async sendUpdate from reaching a dismissed page.
         // prepareForDismissal() may have already done this when closePage() was
         // called programmatically; calling it again is a safe no-op.

--- a/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIPage.kt
+++ b/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIPage.kt
@@ -359,10 +359,31 @@ class VuetaleUIPage(
         sendUpdate()
     }
 
+    // ── Dismissal helpers ──────────────────────────────────────────────────
+
+    /**
+     * Immediately deactivate this page so no further [sendUpdate] calls can be
+     * dispatched while the page is being torn down.
+     *
+     * Must be called **before** any [App.unmount] invocation (e.g. from
+     * [li.kelp.vuetale.app.PlayerUi.closePage]) to close the race window where
+     * Vue's async unmount marks the app dirty, the V8 tick fires [App.onDirty],
+     * and [sendUpdateAsync] calls [sendUpdate] concurrently with Hytale's own
+     * page-teardown logic (which may hold the page lock), causing a thread-
+     * blocking timeout.
+     */
+    internal fun prepareForDismissal() {
+        isActive = false
+        app.onDirty = null
+        app.isDirty = false
+    }
+
     // ── onDismiss ──────────────────────────────────────────────────────────
 
     override fun onDismiss(ref: Ref<EntityStore>, store: Store<EntityStore>) {
         // Prevent any in-flight async sendUpdate from reaching a dismissed page.
+        // prepareForDismissal() may have already done this when closePage() was
+        // called programmatically; calling it again is a safe no-op.
         isActive = false
         // Detach the dirty callback first to avoid any stray update after unmount
         app.onDirty = null

--- a/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIPage.kt
+++ b/src/main/kotlin/li/kelp/vuetale/hytale/VuetaleUIPage.kt
@@ -205,6 +205,7 @@ class VuetaleUIPage(
      * forever.  Dispatching here keeps the V8 tick non-blocking.
      */
     private fun sendUpdateAsync(cmdBuilder: UICommandBuilder, evtBuilder: UIEventBuilder, lockInterface: Boolean) {
+        logger.info("[VuetaleUIPage] sendUpdateAsync(evtBuilder): called for page ${app.getId()}")
         if (DebugConfig.enabled) logger.info ("[vuetaledebug] Update render:\n${app.root.render(0)}")
 
         CompletableFuture.runAsync {
@@ -213,6 +214,7 @@ class VuetaleUIPage(
     }
 
     private fun sendUpdateAsync(cmdBuilder: UICommandBuilder) {
+        logger.info("[VuetaleUIPage] sendUpdateAsync: called for page ${app.getId()}")
         if (DebugConfig.enabled) logger.info ("[vuetaledebug] Update render:\n${app.root.render(0)}")
 
         CompletableFuture.runAsync {
@@ -320,7 +322,11 @@ class VuetaleUIPage(
         // sent by the client after pressing ESC). Without this guard, runOnV8Thread's
         // Future.get() can throw InterruptedException if the thread is interrupted
         // during page teardown.
-        if (!isActive) return
+            logger.info("[VuetaleUIPage] handleDataEvent: entry isActive=$isActive, routingKey='${data.routingKey}'")
+            if (!isActive) {
+                logger.info("[VuetaleUIPage] handleDataEvent: isActive=false, dropping event for routingKey='${data.routingKey}'")
+                return
+            }
 
         // Capture only plain values here – never capture the V8ValueFunction itself outside
         // the V8 thread, because a concurrent hot-reload may close the old runtime and clear
@@ -329,21 +335,23 @@ class VuetaleUIPage(
         val value = data.value
 
         try {
-            JSEngine.instance.runOnV8Thread {
-                // Re-fetch the binding *inside* the V8 task so we always use the live reference.
-                // If a hot-reload fired in the meantime, forceReset() will have cleared the
-                // registry and this returns null – skipping callVoid before touching the closed runtime.
-                val liveBinding = app.eventRegistry.findByRoutingKey(routingKey)
-                if (liveBinding == null) {
-                    logger.warning("No binding found for routingKey='$routingKey' (may be stale after hot-reload)")
-                    return@runOnV8Thread
+                logger.info("[VuetaleUIPage] handleDataEvent: dispatching to V8 thread for routingKey='$routingKey'")
+                JSEngine.instance.runOnV8Thread {
+                    // Re-fetch the binding *inside* the V8 task so we always use the live reference.
+                    // If a hot-reload fired in the meantime, forceReset() will have cleared the
+                    // registry and this returns null – skipping callVoid before touching the closed runtime.
+                    val liveBinding = app.eventRegistry.findByRoutingKey(routingKey)
+                    if (liveBinding == null) {
+                        logger.warning("No binding found for routingKey='$routingKey' (may be stale after hot-reload)")
+                        return@runOnV8Thread
+                    }
+                    logger.info("[VuetaleUIPage] handleDataEvent: invoking callback for routingKey='$routingKey'")
+                    runCatching {
+                        liveBinding.callback.callVoid(null, value)
+                    }.onFailure {
+                        logger.warning("Error invoking callback for '$routingKey': ${it.message}")
+                    }
                 }
-                runCatching {
-                    liveBinding.callback.callVoid(null, value)
-                }.onFailure {
-                    logger.warning("Error invoking callback for '$routingKey': ${it.message}")
-                }
-            }
         } catch (_: InterruptedException) {
             // The server thread was interrupted (e.g. during world shutdown or page dismissal).
             // Restore the interrupt flag and drop this event silently.
@@ -355,8 +363,15 @@ class VuetaleUIPage(
             return
         }
 
-        // Acknowledge the event so Hytale does not consider the page stale
-        sendUpdate()
+        // Acknowledge the event so Hytale does not consider the page stale.
+        // If dismissal started while the callback was running, skip the ack to avoid
+        // racing sendUpdate() against Hytale's page teardown lock path.
+        if (!isActive) {
+            logger.info("[VuetaleUIPage] handleDataEvent: isActive=false after callback, skipping sendUpdate ack for routingKey='$routingKey'")
+            return
+        }
+        logger.info("[VuetaleUIPage] handleDataEvent: calling sendUpdate for routingKey='$routingKey'")
+        runCatching { sendUpdate() }
     }
 
     // ── Dismissal helpers ──────────────────────────────────────────────────
@@ -373,27 +388,33 @@ class VuetaleUIPage(
      * blocking timeout.
      */
     internal fun prepareForDismissal() {
+        logger.info("[VuetaleUIPage] prepareForDismissal: called for page ${app.getId()}")
         isActive = false
         app.onDirty = null
         app.isDirty = false
+        // Keep ESC dismissal lock-safe: cancel app-owned timers without running full Vue unmount.
+        JSEngine.instance.evalScriptAsync("try { _vt.cancelTimersForApp('${app.getId()}'); } catch(e) {}")
     }
 
     // ── onDismiss ──────────────────────────────────────────────────────────
 
     override fun onDismiss(ref: Ref<EntityStore>, store: Store<EntityStore>) {
+        logger.info("[VuetaleUIPage] onDismiss: called for page ${app.getId()}")
         // Prevent any in-flight async sendUpdate from reaching a dismissed page.
         // prepareForDismissal() may have already done this when closePage() was
         // called programmatically; calling it again is a safe no-op.
-        isActive = false
-        // Detach the dirty callback first to avoid any stray update after unmount
-        app.onDirty = null
+        prepareForDismissal()
 
         // Only remove this specific App instance.  If the user opened the page a
         // second time before dismissing the first, the constructor will have already
         // replaced this app in AppManager with a new one.  Calling removeApp by
         // owner+type would then unmount the *new* app, killing the second session.
         if (AppManager.getApp(app.getId()) === app) {
-            AppManager.removeApp(app.owner, app.type)
+            // During ESC-driven onDismiss, avoid full Vue unmount here because it can
+            // race page-lock teardown in Hytale and freeze. forceReset() performs Kotlin-side
+            // cleanup (event bindings, callbacks, dirty state) without V8 blocking work.
+            app.forceReset()
+            AppManager.removeApp(app.owner, app.type, unmount = false)
         }
 
         super.onDismiss(ref, store)

--- a/src/main/resources/manifest.json
+++ b/src/main/resources/manifest.json
@@ -1,7 +1,7 @@
 {
     "Group": "kelp.li",
     "Name": "Vuetale",
-    "Version": "1.0.28",
+    "Version": "1.0.29",
     "Main": "li.kelp.vuetale.Plugin",
     "Description": "Modern Vue.js + TypeScript UI development for Hytale mods. Build reactive, component-based UIs with full autocompletion and excellent tooling while staying fully compatible with Hytale's UI system.",
     "Authors": [

--- a/src/test/kotlin/li/kelp/vuetale/SampleTest.kt
+++ b/src/test/kotlin/li/kelp/vuetale/SampleTest.kt
@@ -1,5 +1,7 @@
 ﻿package li.kelp.vuetale
 
+import com.caoccao.javet.values.V8Value
+import com.caoccao.javet.values.primitive.V8ValueUndefined
 import li.kelp.vuetale.javascript.JSEngine
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Test
@@ -20,18 +22,22 @@ class SampleTest {
 
     @Test
     fun loaderCreatesApp() {
-        // Load loader.js from vuetale/core/ — this also loads renderer.js and the App component
-        // The App component's setup() calls console.log("WORKS!") when the app is created.
-        jsEngine.evalModuleResource("loader.js")
+        // loader.js is initialized by JSEngine startup; create app via _vt.
+        jsEngine.runOnV8Thread {
+            jsEngine.loaderCtx.invoke<V8Value>("createUserApp", "test-app").close()
+        }
 
-        // Trigger app creation — this should print "WORKS!" to stdout via console.log
-        jsEngine.createUserApp("test-app")
-
-        // Verify the USER_APPS global map was populated
-        val res = jsEngine.evalScript("typeof USER_APPS !== 'undefined' && USER_APPS.has('test-app')")
-        val exists = res.asBoolean()
+        // Verify getUserApp() returns a real value instead of undefined.
+        val exists = jsEngine.runOnV8Thread {
+            val value = jsEngine.loaderCtx.invoke<V8Value>("getUserApp", "test-app")
+            try {
+                value !is V8ValueUndefined
+            } finally {
+                value.close()
+            }
+        }
         logger.info("USER_APPS has 'test-app': $exists")
 
-        assertTrue(exists, "Expected USER_APPS to contain 'test-app' after createUserApp()")
+        assertTrue(exists, "Expected _vt.getUserApp('test-app') to return a value after createUserApp()")
     }
 }


### PR DESCRIPTION
## Summary
This PR resolves UI freeze/crash issues observed when sending non-empty arrays through `setData`, and fixes remaining teardown races when closing via `ESC`. It also enforces strict UI replacement semantics: when a new UI opens, the previous one is fully closed first.

## Problem
- Non-empty array or complex payloads passed via `setData` could freeze and eventually crash.
- `ESC` dismissal still had a teardown race path that could block.
- Opening a new UI while one was already open could overlap app state and cause inconsistent behavior.
- Runtime logs became noisy during high-frequency event/update paths.

## What Changed
1. Non-blocking `setData` dispatch
- `setData` now uses fire-and-forget dispatch on the V8 thread instead of waiting with timeout.
- This removes caller-thread stalls during heavy JS/V8 work.

2. JVM → JS payload normalization for `setData`
- Added normalization for `List`, `Array`, `Map`, enums, primitive wrappers, and object graphs before sending to JS.
- Added depth and cycle guards to prevent pathological object traversal.
- Applied normalization both for live `setData` and cached data re-push after engine restart.

3. `ESC` close hardening
- Dismiss path avoids risky full Vue unmount during `onDismiss`.
- Dismissal deactivates dirty/update flow, cancels app timers, force-resets Kotlin-side state, then removes app safely.

4. Strict close-then-open UI replacement
- Added full blocking teardown method to remove old JS app state before creating replacement app.
- `PlayerUi` replacement flow now fully tears down old page first.

5. AppManager removal flexibility
- Added optional `unmount` flag to app removal overloads to support controlled teardown sequencing.

## Additional Included Updates
- Version bump to `1.0.29` in build and manifest files.
- Hytale `0.5.0` API alignment and HUD manager usage updates from related commits.

## Validation
- Local build and compile pass:
  - `./gradlew compileKotlin`
  - `./gradlew build`

## Behavioral Outcome
- `setData` with non-empty arrays no longer blocks caller threads and is normalized into JS-friendly structures.
- `ESC` close path is more robust against teardown deadlocks.
- Opening a new UI now fully closes the existing one before the next UI opens.

## Notes
- No intended breaking API changes for plugin consumers; new removal parameters use defaults for backward compatibility.